### PR TITLE
feat: centralize package versions

### DIFF
--- a/generate_solution.py
+++ b/generate_solution.py
@@ -42,7 +42,8 @@ CS_PROJ_TEMPLATE = """<Project Sdk=\"Microsoft.NET.Sdk{sdk_ext}\">
 {package_refs}</Project>
 """
 
-PACKAGE_REF_TEMPLATE = "    <PackageReference Include=\"{package}\" Version=\"1.0.0\" />\n"
+# Package references omit versions when Directory.Packages.props is used
+PACKAGE_REF_TEMPLATE = "    <PackageReference Include=\"{package}\" />\n"
 
 SLN_HEADER = """Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
@@ -51,7 +52,21 @@ MinimumVisualStudioVersion = 10.0.40219.1
 """
 
 PROJECT_ENTRY_TEMPLATE = "Project(\"{guid}\") = \"{name}\", \"src/{name}/{name}.csproj\", \"{proj_guid}\"\nEndProject\n"
-CONFIG_ENTRY_TEMPLATE = "        {proj_guid}.Debug|Any CPU.ActiveCfg = Debug|Any CPU\n        {proj_guid}.Debug|Any CPU.Build.0 = Debug|Any CPU\n        {proj_guid}.Release|Any CPU.ActiveCfg = Release|Any CPU\n        {proj_guid}.Release|Any CPU.Build.0 = Release|Any CPU\n"
+CONFIG_ENTRY_TEMPLATE = (
+    "        {proj_guid}.Debug|Any CPU.ActiveCfg = Debug|Any CPU\n"
+    "        {proj_guid}.Debug|Any CPU.Build.0 = Debug|Any CPU\n"
+    "        {proj_guid}.Release|Any CPU.ActiveCfg = Release|Any CPU\n"
+    "        {proj_guid}.Release|Any CPU.Build.0 = Release|Any CPU\n"
+)
+
+PROPS_TEMPLATE = """<Project>
+  <ItemGroup>
+{items}  </ItemGroup>
+</Project>
+"""
+
+PROPS_ITEM_TEMPLATE = "    <PackageVersion Include=\"{package}\" Version=\"{version}\" />\n"
+
 
 def create_project(solution: str, project: str, framework: str, db_provider: str):
     project_dir = Path("src") / f"{solution}.{project}"
@@ -78,9 +93,17 @@ def create_project(solution: str, project: str, framework: str, db_provider: str
         )
     return project_dir
 
-def create_solution(solution: str, framework: str, db_provider: str):
+
+def create_solution(
+    solution: str,
+    framework: str,
+    db_provider: str,
+    framework_version: str,
+    ef_version: str,
+):
     project_entries = ""
     config_entries = ""
+    package_versions = {}
     for proj in PROJECTS:
         create_project(solution, proj, framework, db_provider)
         proj_guid = str(uuid.uuid4()).upper()
@@ -91,16 +114,56 @@ def create_solution(solution: str, framework: str, db_provider: str):
             proj_guid=proj_guid,
         )
         config_entries += CONFIG_ENTRY_TEMPLATE.format(proj_guid=proj_guid)
-    sln = SLN_HEADER + project_entries + "Global\n    GlobalSection(SolutionConfigurationPlatforms) = preSolution\n        Debug|Any CPU = Debug|Any CPU\n        Release|Any CPU = Release|Any CPU\n    EndGlobalSection\n    GlobalSection(ProjectConfigurationPlatforms) = postSolution\n" + config_entries + "    EndGlobalSection\n    GlobalSection(SolutionProperties) = preSolution\n        HideSolutionNode = FALSE\n    EndGlobalSection\nEndGlobal\n"
+        for pkg in FRAMEWORK_PACKAGES.get(proj, []):
+            package_versions[pkg] = framework_version
+        if proj == "Infrastructure":
+            package_versions[EF_PACKAGES[db_provider]] = ef_version
+
+    items = "".join(
+        PROPS_ITEM_TEMPLATE.format(package=pkg, version=ver)
+        for pkg, ver in sorted(package_versions.items())
+    )
+    Path("Directory.Packages.props").write_text(PROPS_TEMPLATE.format(items=items))
+
+    sln = (
+        SLN_HEADER
+        + project_entries
+        + "Global\n    GlobalSection(SolutionConfigurationPlatforms) = preSolution\n        Debug|Any CPU = Debug|Any CPU\n        Release|Any CPU = Release|Any CPU\n    EndGlobalSection\n    GlobalSection(ProjectConfigurationPlatforms) = postSolution\n"
+        + config_entries
+        + "    EndGlobalSection\n    GlobalSection(SolutionProperties) = preSolution\n     HideSolutionNode = FALSE\n    EndGlobalSection\nEndGlobal\n"
+    )
     Path(f"{solution}.sln").write_text(sln)
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Generate Clean Architecture solution skeleton")
+    parser = argparse.ArgumentParser(
+        description="Generate Clean Architecture solution skeleton"
+    )
     parser.add_argument("name", help="Solution name")
     parser.add_argument("--framework", choices=["net8.0", "net9.0"], default="net8.0")
-    parser.add_argument("--db-provider", choices=list(EF_PACKAGES.keys()), default="postgresql")
+    parser.add_argument(
+        "--db-provider", choices=list(EF_PACKAGES.keys()), default="postgresql"
+    )
+    parser.add_argument(
+        "--framework-version",
+        default="1.0.0",
+        help="Version for Company.Framework packages",
+    )
+    parser.add_argument(
+        "--ef-version",
+        default="1.0.0",
+        help="Version for EF Core provider package",
+    )
     args = parser.parse_args()
-    create_solution(args.name, args.framework, args.db_provider)
+    create_solution(
+        args.name,
+        args.framework,
+        args.db_provider,
+        args.framework_version,
+        args.ef_version,
+    )
+
 
 if __name__ == "__main__":
     main()
+

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@ This repository contains a minimal Python-based generator that scaffolds a Clean
 ## Usage
 
 ```bash
-python3 generate_solution.py MySolution --framework net9.0 --db-provider postgresql
+python3 generate_solution.py MySolution --framework net9.0 --db-provider postgresql \
+    --framework-version 1.4.0 --ef-version 8.0.0
 ```
 
 The command creates a `MySolution.sln` and the following project layout under `src/`:
@@ -15,7 +16,7 @@ The command creates a `MySolution.sln` and the following project layout under `s
 - `MySolution.Infrastructure`
 - `MySolution.Api`
 
-Each project targets the selected .NET version and includes placeholder package references such as `Company.Framework`. The Infrastructure project also references the chosen EF Core provider package.
+Each project targets the selected .NET version and includes placeholder package references such as `Company.Framework`. Package versions are centralized in a generated `Directory.Packages.props` file. The Infrastructure project also references the chosen EF Core provider package.
 
 ## Visual Studio Extension (Preview)
 


### PR DESCRIPTION
## Summary
- add CLI options for framework and EF Core package versions
- generate Directory.Packages.props to centralize package versions
- document version options in README

## Testing
- `python3 generate_solution.py SampleSolution --framework net9.0 --db-provider postgresql --framework-version 1.2.0 --ef-version 7.0.0`
- `cat Directory.Packages.props`


------
https://chatgpt.com/codex/tasks/task_e_68b1b7178dbc832498d06ab9a27d4a74